### PR TITLE
Add prop-types and create-react-class modules to solve warnings from React v15.*

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8,6 +8,14 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var jQuery = require('jquery'); /**
@@ -20,21 +28,21 @@ var jQuery = require('jquery'); /**
                                   />
                                 */
 
-var ReactScrollPagination = _react2.default.createClass({
+var ReactScrollPagination = (0, _createReactClass2.default)({
   displayName: 'ReactScrollPagination',
 
   propTypes: {
-    fetchFunc: _react.PropTypes.func.isRequired,
-    totalPages: _react.PropTypes.number,
-    paginationShowTime: _react.PropTypes.oneOfType([_react.PropTypes.number, // How long shall the pagination div shows
-    _react.PropTypes.string]),
-    excludeElement: _react.PropTypes.string, // The element selector which should be excluded from calculation
-    excludeHeight: _react.PropTypes.oneOfType([_react.PropTypes.number, // the height value which should be excluded from calculation
-    _react.PropTypes.string]),
-    outterDivStyle: _react.PropTypes.object, // Style of the outter Div element
-    innerDivStyle: _react.PropTypes.object, // Style of the inner Div element
-    triggerAt: _react.PropTypes.oneOfType([_react.PropTypes.number, // The distance to trigger the fetchfunc
-    _react.PropTypes.string])
+    fetchFunc: _propTypes2.default.func.isRequired,
+    totalPages: _propTypes2.default.number,
+    paginationShowTime: _propTypes2.default.oneOfType([_propTypes2.default.number, // How long shall the pagination div shows
+    _propTypes2.default.string]),
+    excludeElement: _propTypes2.default.string, // The element selector which should be excluded from calculation
+    excludeHeight: _propTypes2.default.oneOfType([_propTypes2.default.number, // the height value which should be excluded from calculation
+    _propTypes2.default.string]),
+    outterDivStyle: _propTypes2.default.object, // Style of the outter Div element
+    innerDivStyle: _propTypes2.default.object, // Style of the inner Div element
+    triggerAt: _propTypes2.default.oneOfType([_propTypes2.default.number, // The distance to trigger the fetchfunc
+    _propTypes2.default.string])
   },
   isolate: {
     onePageHeight: null,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "homepage": "https://github.com/codingfishman/react-scroll-pagination#readme",
   "dependencies": {
-    "jquery": "^1.0.0"
+    "create-react-class": "^15.6.2",
+    "jquery": "^1.0.0",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.3",
@@ -34,6 +36,7 @@
     "babel-preset-react": "^6.5.0",
     "eslint": "^2.8.0",
     "eslint-plugin-flow-vars": "^0.3.0",
+    "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "jest-cli": "*",
     "jscs": "^3.0.3",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,10 +8,12 @@
   />
 */
 
-import React, { PropTypes } from 'react'
+import React, { Component } from 'react'
+import createReactClass from 'create-react-class'
+import PropTypes from 'prop-types'
 const jQuery = require('jquery')
 
-const ReactScrollPagination = React.createClass({
+const ReactScrollPagination = createReactClass({
   propTypes: {
     fetchFunc: PropTypes.func.isRequired,
     totalPages: PropTypes.number,


### PR DESCRIPTION
Before `prop-types` and `create-react-class` modules, this component had two warnings when React Version is 15.*

```
"Warning: Accessing createClass via the main React package is deprecated, and will be removed in React v16.0. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class v15.* is available on npm as a temporary, drop-in replacement. For more info see https://fb.me/react-create-class"
```

and

```
"Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs"
```

This pull request solve the warnings